### PR TITLE
Allow multi doc structures

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,15 @@ module.exports = function(source) {
   try {
     const options = getOptions(this) || {};
     const safe = options.safe !== false;
-    const res = safe ? yaml.safeLoad(source) : yaml.load(source);
-    return `module.exports = ${uneval(res)};`;
+
+    const res = safe
+      ? yaml.safeLoadAll(source)
+      : yaml.loadAll(source);
+
+    return [
+      `const doc = ${uneval(res)};`,
+      'module.exports = doc.length <= 1 ? doc[0] : doc;'
+    ].join('\n');
   } catch (err) {
     this.emitError(err);
     return null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-yaml-loader",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "YAML loader for webpack",
   "main": "index.js",
   "repository": "https://github.com/wwilsman/js-yaml-loader.git",


### PR DESCRIPTION
Fixes #7 

We can't simply replace `load` and `safeLoad` with their `loadAll` counterparts as that would make it so an array is _always_ returned from imported YAML.

But we **can** use their `loadAll` counterparts and check the document length in the output to decide if one or more documents were loaded.

In the case of multiple documents an array is returned, if only a single document is found just that document is returned. This allows it to remain compatible with the existing functionality and also support multi-document structures at the same time.

This PR will release v1.1.0