### PR TITLE
Allow other js-yaml options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,32 @@ module: {
 
 ### safe *(boolean) (default=true)*
 
-Use [`safeLoad`](https://github.com/nodeca/js-yaml#safeload-string---options-) instead of [`load`](https://github.com/nodeca/js-yaml#load-string---options-). Set `safe` to `false` to allow unsafe types to load, such as regular expressions, functions, and `undefined`.
+Use [`safeLoad`](https://github.com/nodeca/js-yaml#safeload-string---options-)
+instead of [`load`](https://github.com/nodeca/js-yaml#load-string---options-).
+Set `safe` to `false` to allow unsafe types to load, such as regular
+expressions, functions, and `undefined`.
 
-### Difference from [yaml-loader](https://github.com/okonet/yaml-loader)
+### iterator *(function) (default=undefined)*
+
+The [`iterator`](https://github.com/nodeca/js-yaml#safeloadall-string--iterator--options-)
+option passed to `safeLoadAll` and `loadAll`. Applies `iterator` to each
+document if specified.
+
+### ...options
+
+Any other options are passed directly to to `safeLoad` or `load` as the
+[`options`](https://github.com/nodeca/js-yaml#safeload-string---options-)
+parameter.
+
+## Difference from [yaml-loader](https://github.com/okonet/yaml-loader)
 
 [yaml-loader](https://github.com/okonet/yaml-loader) loads YAML files
-as _JSON_ and is commonly used in conjuction with
-[json-loader](https://github.com/webpack-contrib/json-loader).
+as _JSON_ and is commonly used in conjuction with [json-loader](https://github.com/webpack-contrib/json-loader).
 
-In contrast, this loader loads YAML files as JavaScript objects using
-the [un-eval](https://github.com/tiansh/un_eval.js) library. This allows YAML value types otherwise
-disallowed in JSON such as `Infinity`, `RegExp`, `Function`, etc.
-[See js-yaml's supported YAML types](https://github.com/nodeca/js-yaml#supported-yaml-types)
+In contrast, this loader loads YAML files as JavaScript objects using the
+[un-eval](https://github.com/tiansh/un_eval.js) library. This allows YAML value
+types otherwise disallowed in JSON such as `Infinity`, `RegExp`, `Function`,
+etc. [See js-yaml's supported YAML types](https://github.com/nodeca/js-yaml#supported-yaml-types)
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -6,12 +6,15 @@ module.exports = function(source) {
   this.cacheable && this.cacheable();
 
   try {
-    const options = getOptions(this) || {};
-    const safe = options.safe !== false;
+    const {
+      safe,
+      iterator,
+      ...options
+    } = getOptions(this) || {};
 
-    const res = safe
-      ? yaml.safeLoadAll(source)
-      : yaml.loadAll(source);
+    const res = safe !== false
+      ? yaml.safeLoadAll(source, iterator, options)
+      : yaml.loadAll(source, iterator, options);
 
     return [
       `const doc = ${uneval(res)};`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-yaml-loader",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "YAML loader for webpack",
   "main": "index.js",
   "repository": "https://github.com/wwilsman/js-yaml-loader.git",


### PR DESCRIPTION
Thanks to @jeanphilippeds and #10 for the suggestion!

Instead of having a default iterator and passing _all_ options to js-yaml, this PR allows `iterator` to be undefined and any remaining options are passed along as the `options` parameter.

This PR also updates the README and releases v1.2.0