### PR TITLE
Make readme usage more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,16 @@
 
 ## Usage
 
-[Webpack documentation](https://webpack.js.org/concepts/loaders/#using-loaders)
+[Webpack documentation on using loaders.](https://webpack.js.org/concepts/loaders/#using-loaders)
+
+Using the loader inline:
 
 ``` javascript
 import doc from 'js-yaml-loader!./file.yml';
 // => returns a javascript object. see https://github.com/nodeca/js-yaml
 ```
+
+Or using the loader via Webpack configuration (recommended):
 
 ``` javascript
 // webpack.config.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-yaml-loader",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "YAML loader for webpack",
   "main": "index.js",
   "repository": "https://github.com/wwilsman/js-yaml-loader.git",


### PR DESCRIPTION
#14 came across an issue with using the loader twice by mistake, this hopefully makes it a little more clear that there are two methods to using loaders and one is recommended over the other.

This will release v1.2.2 so that NPM gets the updated readme as well